### PR TITLE
Rename `validate` to `appimagevalidate`

### DIFF
--- a/ci/build-appimages.sh
+++ b/ci/build-appimages.sh
@@ -62,12 +62,15 @@ fi
 
 # remove unnecessary binaries from AppDirs
 rm AppImageUpdate.AppDir/usr/bin/appimageupdatetool
-rm AppImageUpdate.AppDir/usr/bin/validate
+rm AppImageUpdate.AppDir/usr/bin/appimagevalidate
 rm appimageupdatetool.AppDir/usr/bin/AppImageUpdate
-rm appimageupdatetool.AppDir/usr/bin/validate
+rm appimageupdatetool.AppDir/usr/bin/appimagevalidate
 rm appimageupdatetool.AppDir/usr/lib/*/libappimageupdate-qt*.so*
 rm validate.AppDir/usr/bin/{AppImageUpdate,appimageupdatetool}
 rm validate.AppDir/usr/lib/*/libappimageupdate*.so*
+
+# AppDir data expects old name, which is fine for an AppImage
+mv validate.AppDir/usr/bin/appimagevalidate validate.AppDir/usr/bin/validate
 
 
 # remove other unnecessary data

--- a/src/signing/CMakeLists.txt
+++ b/src/signing/CMakeLists.txt
@@ -14,11 +14,11 @@ target_include_directories(signing
 
 # "demonstration" application
 # used to be located within AppImageKit, but there is no sense in maintaining two implementations
-add_executable(validate validate_main.cpp)
-target_link_libraries(validate signing ${CMAKE_THREAD_LIBS_INIT})
+add_executable(appimagevalidate validate_main.cpp)
+target_link_libraries(appimagevalidate signing ${CMAKE_THREAD_LIBS_INIT})
 
 # install target
 install(
-    TARGETS validate
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT validate
+    TARGETS appimagevalidate
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT appimagevalidate
 )


### PR DESCRIPTION
This is not a good idea for a binary name; it conflicts on my system.

I understand it started as an example program but when installed it no longer makes sense to call it just `validate`. However, I moved it back to the old name in the AppImage build. :-)