### PR TITLE
add include for <sstream> to fix build failure under clang/libc++

### DIFF
--- a/src/signing/signaturevalidator.cpp
+++ b/src/signing/signaturevalidator.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <sstream>
 
 // library headers
 #include <gpgme.h>


### PR DESCRIPTION
appimageupdate was failing to build using clang 15 and libc++15 , the error was use of undefined template for std::stringstream, this is quite common for something to compile under stdlibc++11 but fail under libc++ due to one library including a header in another header but the other library not. 