### PR TITLE
Fix ZSync matching pattern

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
     name: Create release and upload artifacts
     needs:
       - appimage-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v2

--- a/src/updateinformation/GithubReleasesZsyncUpdateInformation.cpp
+++ b/src/updateinformation/GithubReleasesZsyncUpdateInformation.cpp
@@ -47,7 +47,7 @@ namespace appimage::update::updateinformation {
         }
 
         // not ideal, but allows for returning a match for the entire line
-        auto pattern = "*" + filename + "*";
+        auto pattern = "*" + filename;
 
         const auto& assets = json["assets"];
 


### PR DESCRIPTION
The current pattern matches files that don't end with '.zsync', like VScodium's release hashes:

    Raw update information: gh-releases-zsync|VSCodium|vscodium|latest|*.AppImage.zsync
    Assembled ZSync URL: https://github.com/VSCodium/vscodium/releases/download/1.75.0.23033/VSCodium-1.75.0.23033.glibc2.17-x86_64.AppImage.zsync.sha256

To fix this, the "*" at the end of the pattern should be removed. It's not needed to match the file, since filenames in the update information only end in '.zsync':

    Raw update information: gh-releases-zsync|VSCodium|vscodium|latest|*.AppImage.zsync
    Assembled ZSync URL: https://github.com/VSCodium/vscodium/releases/download/1.75.0.23033/VSCodium-1.75.0.23033.glibc2.17-x86_64.AppImage.zsync

This also closes https://github.com/AppImageCommunity/AppImageUpdate/issues/215