### PR TITLE
Fix overwrite+remove deleting the wrong file on relative path.

### DIFF
--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -60,7 +60,9 @@ int main(const int argc, const char** argv) {
 
     optional<string> pathToAppImage = [&args]() {
         if (!args.pos.empty()) {
-            return optional<string>(args.as<string>(0));
+            // calculate absolute path to normalize the path for when it's
+            // checked back from Updater::pathToNewFile
+            return optional<string>(abspath(args.as<string>(0)));
         }
 
         return optional<string>();
@@ -239,6 +241,9 @@ int main(const int argc, const char** argv) {
         cerr << "Fatal error: could not determine path to new file!" << endl;
         return 1;
     }
+
+    // normalize against pathToAppImage - so they follow the same format
+    newFilePath = abspath(newFilePath);
 
     auto validationResult = updater.validateSignature();
 


### PR DESCRIPTION
Fixes #234

The issue seems to be happening due to:

```cpp
    auto oldFilePath = pathToOldAppImage(pathToAppImage.value(), newFilePath);
```

checking in `pathToOldAppImage` if the paths are [trivially] equal with a == before, but newFilePath is gathered through `pathToNewFile`, which gets the data from the zSyncClient object:

```cpp
    bool Updater::pathToNewFile(std::string& path) const {
        // only available update method is via ZSync
        if (d->zSyncClient)
            return d->zSyncClient->pathToNewFile(path);

        return false;
    }
```

which internally calls `applyCwdToPathToLocalFile`, which one of the 3 places where `pathToLocalFile` is modified:
1) constructor, when the file needs to be overwritten
2) populatePathToLocalFileFromZSyncFile
3) **applyCwdToPathToLocalFile**

```cpp
        void applyCwdToPathToLocalFile() {
            if (strncmp(pathToLocalFile.c_str(), "/", 1) == 0)
                return;

            auto oldPath = pathToLocalFile;
            pathToLocalFile = cwd;
            if (!endsWith(pathToLocalFile, "/"))
                pathToLocalFile += "/";
            pathToLocalFile += oldPath;
        }
```

which will make relative paths absolute, and keep absolute paths 100% equal

I haven't touched this codebase ever, so I'm just going based off vibes for the solution, if there's a better place to put to abspath - to keep the change minimal, that could likely be better, from what I can tell there's quite a few places in updater.cpp where the paths are normalized, like `Updater::restoreOriginalFile` and `Updater::copyPermissionsToNewFile` 😅

I'm not using Linux - so @Samueru-sama has been testing the code 🫡