### PR TITLE
Fix GithubReleasesUpdateInformation::buildUrl()

### DIFF
--- a/src/updateinformation/GithubReleasesZsyncUpdateInformation.cpp
+++ b/src/updateinformation/GithubReleasesZsyncUpdateInformation.cpp
@@ -63,8 +63,9 @@ namespace appimage::update::updateinformation {
 
         for (const auto& asset : assets) {
             const auto browserDownloadUrl = asset["browser_download_url"].get<std::string>();
+            const auto name = asset["name"].get<std::string>();
 
-            if (fnmatch(pattern.c_str(), browserDownloadUrl.c_str(), 0) == 0) {
+            if (fnmatch(pattern.c_str(), name.c_str(), 0) == 0) {
                 matchingUrls.emplace_back(browserDownloadUrl);
             }
         }


### PR DESCRIPTION
Fixes #252

The release asset matching is currently broken on `main`, as it compares against the `browser_download_url` instead of `name`, which can make the AppImage's update pattern accidentally match the repo name in the download URL instead of just the release asset names, leading to a wrong asset selection when trying to update. I have described the issue in detail in #252.

This incorrect matching in the URL is only possible because of the added asterisk char `*` at the beginning of the pattern a few lines above my changes, here:
https://github.com/AppImageCommunity/AppImageUpdate/blob/673af3cbe79fef73f1687a34bf5ebe94d6df5cdd/src/updateinformation/GithubReleasesZsyncUpdateInformation.cpp#L49-L50

I was not sure if you'd want to keep this for compatibility reasons, so I didn't change it.

The [AppImage spec](https://github.com/AppImage/AppImageSpec/blob/master/draft.md#github-releases) however explicitly mentions the file name for matching, not the download URL, so maybe this should be removed, considering the spec's pattern example.

In regards to the sorting at the bottom that is based on the `browser_download_url` value, that should be fine, as it's the same sorting result after only adding the entries with a matching `name` to the `matchingUrls`.

I have validated these changes and the current version from `main` on a temporary test repo (with a renamed repo while using the `main` version, for proving the issue).